### PR TITLE
Added in URLs for documentation headers

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -11,6 +11,7 @@ main:
 
 docs:
   - title: Getting Started
+    url: /docs/introduction
     children:
       - title: "Introduction"
         url: /docs/introduction/
@@ -22,6 +23,7 @@ docs:
         url: /docs/extensions/
 
   - title: TTY client
+    url: /docs/keybindings
     children:
       - title: "Keybindings"
         url: /docs/keybindings/
@@ -31,6 +33,7 @@ docs:
         url: /docs/mosh/
 
   - title: In-browser client
+    url: /docs/in-browser-usage
     children:
       - title: "Usage"
         url: /docs/in-browser-usage/


### PR DESCRIPTION
I have added in URLs for the headers inside the documentation so the user can click on it and redirect.
Inside the _data/navigation.yml file, there were no redirects to a URL when you click on the parent header for a section inside the Documentation. I have added this feature.