### PR TITLE
Fix the capitalization of 'GitHub'

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -6,7 +6,7 @@ main:
     url: /docs/introduction/
   - title: "Donate"
     url: /donate/
-  - title: "Github"
+  - title: "GitHub"
     url: https://github.com/browsh-org/browsh
 
 docs:

--- a/_docs/03-terminals.md
+++ b/_docs/03-terminals.md
@@ -13,7 +13,7 @@ that Browsh will then have full-functionality. Some terminals may have other iss
 
 At the very least you should ensure you have a monospaced font in your terminal. This is almost always the case by default. Even so, you may still wish to change the font, or at least the font settings, to better support the UTF-8 half block (▄), which is responsible for rendering Browsh's graphics. There are 3 main issues you need to look out for:
 
-  1. The font simply doesn't contain the UTF-8 half block character. Most of the fonts here at Github's [ProgrammingFonts/ProgrammingFonts](https://github.com/ProgrammingFonts/ProgrammingFonts) repo have it, so consider changing.
+  1. The font simply doesn't contain the UTF-8 half block character. Most of the fonts here at GitHub's [ProgrammingFonts/ProgrammingFonts](https://github.com/ProgrammingFonts/ProgrammingFonts) repo have it, so consider changing.
   2. The font's glyph for the UTF-8 half block character isn't actually a true half-block, usually it's slightly smaller, this causes thin empty bands to appear on the page. I don't find this a big issue, but if you want perfection then first consider the next point or try a different font.
   3. Your terminal doesn't align fonts perfectly in their cells. Some terminals allow you to change things like the padding around characters or their X and Y offset. Try playing with these settings to remove any banding artefacts.
 

--- a/donate.html
+++ b/donate.html
@@ -53,7 +53,7 @@ donation, as these allow me to make longer term and larger plans for Browsh.
 </p>
 
 <p>
-However, you can also show your support by making contributions on Github, sharing Browsh
+However, you can also show your support by making contributions on GitHub, sharing Browsh
 with your friends, or just sending me an email or tweet with suggestions or critical
 feedback.
 </p>

--- a/downloads.md
+++ b/downloads.md
@@ -36,7 +36,7 @@ or better yet [Mosh](https://mosh.org/) (though note that self-compiling Mosh is
 
 **It doesn't work on Windows**    
 This is a known bug, it's not been a top priority because of the main usecase described
-in the previous FAQ answer here. Please follow this [Github issue](https://github.com/browsh-org/browsh/issues/32) for updates.
+in the previous FAQ answer here. Please follow this [GitHub issue](https://github.com/browsh-org/browsh/issues/32) for updates.
 
 **It works but the graphics has long black lines in it**    
 Your terminal doesn't support true colour, see here for more details: [https://gist.github.com/XVilka/8346728](https://gist.github.com/XVilka/8346728)

--- a/html-service-welcome.md
+++ b/html-service-welcome.md
@@ -9,7 +9,7 @@ To use it you need only prefix normal URLs with 'html.brow.sh'. For example;
 
 [html.brow.sh/https://en.wikipedia.org/wiki/Internet](https://en.wikipedia.org/wiki/Internet)
 
-This service is still very much in its early days, so you will likely find many pages with rendering issues. Please report specific URLs on [Browsh's Github repo](https://github.com/browsh-org/browsh/issues).
+This service is still very much in its early days, so you will likely find many pages with rendering issues. Please report specific URLs on [Browsh's GitHub repo](https://github.com/browsh-org/browsh/issues).
 
 All rendered pages are cached by a global CDN for at least 5 minutes, so you'll need to wait to trigger a re-render. Also there is a rate limit of around 10 requests per minute per IP address.
 


### PR DESCRIPTION
`Github` -> `GitHub`

```sh
$ find . -type f -exec sed -i 's|Github|GitHub|g' {} \;
```
